### PR TITLE
Add various files to the setuptools distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+include requirements.txt


### PR DESCRIPTION
Addresses that the source tarball produced by 'python setup.py sdist'
can't be built or installed since requirements.txt (referred from
setup.py) is missing. Also adding LICENSE and README.md since those
are reasonable files to have in a source distribution.
